### PR TITLE
Fixed version for m365 cli + fix scope param

### DIFF
--- a/pipelines/deploy/spfx/spfx-app.yml
+++ b/pipelines/deploy/spfx/spfx-app.yml
@@ -89,8 +89,8 @@ steps:
   - script: |
       m365 spo app deploy \
         --appCatalogUrl ${{ parameters.appCatalogUrl }} \
+        --appCatalogScope ${{ parameters.appCatalogScope }} \
         --name $(PackageFileName) \
-        --scope ${{ parameters.appCatalogScope }} \
         --verbose \
         ${{ parameters.extraDeployArgs }}
     displayName: 'Deploy SPFx package'

--- a/pipelines/deploy/spfx/spfx-app.yml
+++ b/pipelines/deploy/spfx/spfx-app.yml
@@ -48,7 +48,7 @@ steps:
           secureFile: ${{ parameters.certificateFile }}
 
   - script: |
-      yarn global add @pnp/cli-microsoft365
+      yarn global add @pnp/cli-microsoft365@6
     displayName: 'Install M365 CLI'
 
   - ${{ if ne(parameters.certificateFile, '') }}:
@@ -74,8 +74,8 @@ steps:
   - script: |
       m365 spo app add \
         --appCatalogUrl ${{ parameters.appCatalogUrl }} \
+        --appCatalogScope ${{ parameters.appCatalogScope }} \
         --filePath ${{ parameters.package }} \
-        --scope ${{ parameters.appCatalogScope }} \
         --overwrite \
         --verbose
     displayName: 'Upload SPFx package'


### PR DESCRIPTION
 - Set the installed version of the m365 cli fixed to v6
 - Use the correct scope param for the `spo add app` command (appCatalogScope)