### PR TITLE
Node version + M365 CLI version parameters

### DIFF
--- a/pipelines/deploy/spfx/spfx-app.yml
+++ b/pipelines/deploy/spfx/spfx-app.yml
@@ -72,18 +72,12 @@ steps:
 
   - ${{ if ne(parameters.certificateFile, '') }}:
       - script: |
-          m365 login --authType certificate --certificateFile $(deploymentCertificate.secureFilePath)
+          m365 login --appId ${{ parameters.aadClientId }} --tenant ${{ parameters.aadTenantId }} --authType certificate --certificateFile $(deploymentCertificate.secureFilePath)
         displayName: 'Connect to SharePoint Online'
-        env:
-          CLIMICROSOFT365_AADAPPID: ${{ parameters.aadClientId }}
-          CLIMICROSOFT365_TENANT: ${{ parameters.aadTenantId }}
   - ${{ elseif ne(parameters.certificateFilePath, '') }}:
       - script: |
-          m365 login --authType certificate --certificateFile ${{ parameters.certificateFilePath }}
+          m365 login --appId ${{ parameters.aadClientId }} --tenant ${{ parameters.aadTenantId }} --authType certificate --certificateFile ${{ parameters.certificateFilePath }}
         displayName: 'Connect to SharePoint Online'
-        env:
-          CLIMICROSOFT365_AADAPPID: ${{ parameters.aadClientId }}
-          CLIMICROSOFT365_TENANT: ${{ parameters.aadTenantId }}
   - ${{ else }}:
       - script: |
           echo "No authentication certificate specified."


### PR DESCRIPTION
Added a node version + M365 CLI version parameter to the spfx deploy pipeline template.

If no node version is passed, no explicit node version will be set.
If no M365 CLI version is passed, the default value (6) will be used.