### PR TITLE
fix(m365login): Fix m365 login with multiline PEM for SPFx deploy + PFX support

### DIFF
--- a/pipelines/deploy/spfx/spfx-app.yml
+++ b/pipelines/deploy/spfx/spfx-app.yml
@@ -76,20 +76,26 @@ steps:
   - ${{ if ne(parameters.certificateFile, '') }}:
       - script: |
           m365 login --appId ${{ parameters.aadClientId }} --tenant ${{ parameters.aadTenantId }} --authType certificate --certificateFile $(deploymentCertificate.secureFilePath)
-        displayName: 'Connect to SharePoint Online'
+        displayName: 'Connect to SharePoint Online (secure file)'
   - ${{ elseif ne(parameters.certificateFilePath, '') }}:
       - script: |
           m365 login --appId ${{ parameters.aadClientId }} --tenant ${{ parameters.aadTenantId }} --authType certificate --certificateFile ${{ parameters.certificateFilePath }}
-        displayName: 'Connect to SharePoint Online'
+        displayName: 'Connect to SharePoint Online (certificate file path)'
   - ${{ elseif ne(parameters.certificateBase64Encoded, '') }}:
       - script: |
-          m365 login --appId ${{ parameters.aadClientId }} --tenant ${{ parameters.aadTenantId }} --authType certificate --certificateBase64Encoded ${{ parameters.certificateBase64Encoded }} 
-        displayName: "Connect to SharePoint Online"
+          printf "%s" "${{ parameters.certificateBase64Encoded }}" > "$(Agent.TempDirectory)/cert.pem"
+
+          m365 login \
+            --appId "${{ parameters.aadClientId }}" \
+            --tenant "${{ parameters.aadTenantId }}" \
+            --authType certificate \
+            --certificateFile "$(Agent.TempDirectory)/cert.pem"
+        displayName: "Connect to SharePoint Online (base64 encoded certificate)"
   - ${{ else }}:
       - script: |
           echo "No authentication certificate specified."
           exit 1
-        displayName: 'Connect to SharePoint Online'
+        displayName: 'Connect to SharePoint Online (failed)'
 
   - script: |
       m365 spo app add \

--- a/pipelines/deploy/spfx/spfx-app.yml
+++ b/pipelines/deploy/spfx/spfx-app.yml
@@ -30,6 +30,10 @@ parameters:
     type: string
     default: ''
     displayName: 'Base64-encoded string with certificate private key'
+  - name: certificatePassword
+    type: string
+    default: ''
+    displayName: 'Password for the certificate (if required, for PFX)'
   - name: aadClientId
     type: string
     displayName: "Azure AD deployment application's client ID."
@@ -81,6 +85,17 @@ steps:
       - script: |
           m365 login --appId ${{ parameters.aadClientId }} --tenant ${{ parameters.aadTenantId }} --authType certificate --certificateFile ${{ parameters.certificateFilePath }}
         displayName: 'Connect to SharePoint Online (certificate file path)'
+  - ${{ elseif and(ne(parameters.certificateBase64Encoded, ''), ne(parameters.certificatePassword, '')) }}:
+      - script: |
+          printf "%s" "${{ parameters.certificateBase64Encoded }}" > "$(Agent.TempDirectory)/cert.pfx"
+
+          m365 login \
+            --appId "${{ parameters.aadClientId }}" \
+            --tenant "${{ parameters.aadTenantId }}" \
+            --authType certificate \
+            --certificateFile "$(Agent.TempDirectory)/cert.pfx" \
+            --password "${{ parameters.certificatePassword }}"
+        displayName: "Connect to SharePoint Online (base64 PFX certificate)"
   - ${{ elseif ne(parameters.certificateBase64Encoded, '') }}:
       - script: |
           printf "%s" "${{ parameters.certificateBase64Encoded }}" > "$(Agent.TempDirectory)/cert.pem"
@@ -90,7 +105,7 @@ steps:
             --tenant "${{ parameters.aadTenantId }}" \
             --authType certificate \
             --certificateFile "$(Agent.TempDirectory)/cert.pem"
-        displayName: "Connect to SharePoint Online (base64 encoded certificate)"
+        displayName: "Connect to SharePoint Online (base64 PEM certificate)"
   - ${{ else }}:
       - script: |
           echo "No authentication certificate specified."


### PR DESCRIPTION
🔨 Fix m365 login, when using a PEM file. PEM content is multiline and gives issues while using a single line command. Using a temporary certificate file to resolve this.

Also added support for PFX file, which needs a password parameter since it is most of the time password protected.

ℹ️ Even though the string is not base64 encode, I left the parameter name the same to not break any existing pipelines. On the original code, also no decoding is done on the string.